### PR TITLE
Remove Basic Authentication for Hydra 1.x upgrade

### DIFF
--- a/lib/omniauth-rpi/version.rb
+++ b/lib/omniauth-rpi/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Rpi
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/rpi.rb
+++ b/lib/omniauth/strategies/rpi.rb
@@ -15,15 +15,6 @@ class OmniAuth::Strategies::Rpi < OmniAuth::Strategies::OAuth2
     end
   end
 
-  def build_access_token
-    options.token_params[:headers] = { 'Authorization' => basic_auth_header }
-    super
-  end
-
-  def basic_auth_header
-    'Basic ' + Base64.strict_encode64("#{options[:client_id]}:#{options[:client_secret]}")
-  end
-
   def callback_url
     full_host + callback_path
   end


### PR DESCRIPTION
Also: bumped version to allow for older clients to still work