### PR TITLE
Add username to v0 strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,6 @@ use OmniAuth::Builder do
 end
 ```
 
+## Publishing changes
 
+When publishing changes to the provider, don't forget to bump the version number in `lib/omniauth-rpi/version.rb`

--- a/lib/omniauth-rpi/version.rb
+++ b/lib/omniauth-rpi/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Rpi
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/hydra0.rb
+++ b/lib/omniauth/strategies/hydra0.rb
@@ -34,6 +34,7 @@ module OmniAuth::Strategies
     info do
       {
         'email'    => email,
+        'username' => username,
         'name'     => fullname,
         'nickname' => nickname,
         'image'    => image,
@@ -52,6 +53,11 @@ module OmniAuth::Strategies
 
     def email
       raw_info['email']
+    end
+
+    # <13 accounts have username instead of email
+    def username
+      raw_info['username']
     end
 
     def nickname

--- a/lib/rpi_auth_bypass.rb
+++ b/lib/rpi_auth_bypass.rb
@@ -3,6 +3,7 @@
 module RpiAuthBypass
   DEFAULT_UID = 'b6301f34-b970-4d4f-8314-f877bad8b150'
   DEFAULT_EMAIL = 'web@raspberrypi.org'
+  DEFAULT_USERNAME = 'webteam'
   DEFAULT_NAME = 'Web Team'
   DEFAULT_NICKNAME = 'Web'
   DEFAULT_PROFILE = 'https://profile.raspberrypi.org/not/a/real/path'
@@ -15,6 +16,7 @@ module RpiAuthBypass
     name: DEFAULT_NAME,
     nickname: DEFAULT_NICKNAME,
     email: DEFAULT_EMAIL,
+    username: DEFAULT_USERNAME,
     image: DEFAULT_IMAGE,
   }.freeze
   DEFAULT_EXTRA = {
@@ -23,6 +25,7 @@ module RpiAuthBypass
       name: DEFAULT_NAME,
       nickname: DEFAULT_NICKNAME,
       email: DEFAULT_EMAIL,
+      username: DEFAULT_USERNAME,
       country: DEFAULT_COUNTRY,
       country_code: DEFAULT_COUNTRY_CODE,
       postcode: DEFAULT_POSTCODE,

--- a/spec/rpi_auth_bypass_spec.rb
+++ b/spec/rpi_auth_bypass_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe RpiAuthBypass do
       expect(subject.info.email).to eq(RpiAuthBypass::DEFAULT_EMAIL)
     end
 
+    it 'has the default username' do
+      expect(subject.info.username).to eq(RpiAuthBypass::DEFAULT_USERNAME)
+    end
+
     it 'has the default name' do
       expect(subject.info.name).to eq(RpiAuthBypass::DEFAULT_NAME)
     end
@@ -86,6 +90,7 @@ RSpec.describe RpiAuthBypass do
       let(:name) { 'Robert Flemming' }
       let(:nickname) { 'Bob' }
       let(:email) { 'bob.flemming@example.com' }
+      let(:username) { 'bob.flemming' }
       let(:roles) { 'gardener' }
       let(:image) { 'https://my.avatar.com/image/1' }
       let(:profile) { 'https://my.user.com/profile/1' }
@@ -93,10 +98,11 @@ RSpec.describe RpiAuthBypass do
       let(:country_code) { 'US' }
       let(:postcode) { '123456' }
 
-      let(:info) { { name: name, email: email, nickname: nickname, image: image } }
+      let(:info) { { name: name, email: email, username: username, nickname: nickname, image: image } }
       let(:extra) { { raw_info: { 
         name: name,
         email: email,
+        username: username,
         nickname: nickname,
         roles: roles,
         avatar: image,
@@ -115,6 +121,10 @@ RSpec.describe RpiAuthBypass do
         expect(subject.info.email).to eq(email)
       end
 
+      it 'has the username from info' do
+        expect(subject.info.username).to eq(username)
+      end
+
       it 'has the name from info' do
         expect(subject.info.name).to eq(name)
       end
@@ -129,6 +139,10 @@ RSpec.describe RpiAuthBypass do
 
       it 'has the email from extra' do
         expect(subject.extra.raw_info.email).to eq(email)
+      end
+
+      it 'has the username from extra' do
+        expect(subject.extra.raw_info.username).to eq(username)
       end
 
       it 'has the name from extra' do


### PR DESCRIPTION
<13 accounts have a `username` rather than `email`; this needs to be exposed to the application also.