### PR TITLE
Relax jwt version constraint

### DIFF
--- a/omniauth-rpi.gemspec
+++ b/omniauth-rpi.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  spec.add_runtime_dependency 'jwt', '~> 2.2.3'
+  spec.add_runtime_dependency 'jwt', '~> 2.2'
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
   spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
 


### PR DESCRIPTION
## What's changed?

As the latest version of omniauth-google-oauth2 (1.2.1) requires jwt 2.9.2, it's not possible to install alongside this gem as it will only allow up to jwt 2.3.0 due to its use of the "twiddle-wakka" with a patch level version number (see https://guides.rubygems.org/patterns/#pessimistic-version-constraint).

## Steps to perform after merge

New version (possibly 1.4.1?) needs to be documented in the CHANGELOG, tagged, and released.
